### PR TITLE
preliminary support for 2.80+

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,8 @@ bl_info = {
     "category": "Import-Export",
     "author": "AsteriskAmpersand (Code) & Seth VanHeulen (Vertex and Face Buffer Structure)",
     "location": "File > Import-Export > PMO/MH",
-    "version": (1,0,0)
+    "version": (1,0,0),
+    "blender": (2, 80, 0),
 }
  
 import bpy
@@ -29,14 +30,14 @@ classes = [ImportPMO,ImportFUAHI,ConvertAHI]
 def register():
     for cl in classes:
         bpy.utils.register_class(cl)
-    bpy.types.INFO_MT_file_import.append(pmo_model_menu_func_import)
-    bpy.types.INFO_MT_file_import.append(ahi_skeleton_menu_func_import)
+    bpy.types.TOPBAR_MT_file_import.append(pmo_model_menu_func_import)
+    bpy.types.TOPBAR_MT_file_import.append(ahi_skeleton_menu_func_import)
 
 def unregister():
     for cl in classes:
-        bpy.utils.register_class(cl)
-    bpy.types.INFO_MT_file_import.remove(pmo_model_menu_func_import)
-    bpy.types.INFO_MT_file_import.append(ahi_skeleton_menu_func_import)
+        bpy.utils.unregister_class(cl)
+    bpy.types.TOPBAR_MT_file_import.remove(pmo_model_menu_func_import)
+    bpy.types.TOPBAR_MT_file_import.remove(ahi_skeleton_menu_func_import)
     
 
 if __name__ == "__main__":

--- a/operators/ahi_converter.py
+++ b/operators/ahi_converter.py
@@ -41,12 +41,12 @@ def createArmature(rootBone):#Skeleton
     bpy.ops.object.select_all(action='DESELECT')
     blenderArmature = bpy.data.armatures.new('Armature')
     arm_ob = bpy.data.objects.new('Armature', blenderArmature)
-    bpy.context.scene.objects.link(arm_ob)
-    bpy.context.scene.update()
-    arm_ob.select = True
-    arm_ob.show_x_ray = True
-    bpy.context.scene.objects.active = arm_ob
-    blenderArmature.draw_type = 'STICK'
+    bpy.context.scene.collection.objects.link(arm_ob)
+    bpy.context.view_layer.update()
+    arm_ob.select_set(True)
+    arm_ob.show_in_front = True
+    bpy.context.view_layer.objects.active = arm_ob
+    arm_ob.data.display_type = 'STICK'
     bpy.ops.object.mode_set(mode='EDIT')    
     empty = createParentBone(blenderArmature)
     
@@ -54,7 +54,7 @@ def createArmature(rootBone):#Skeleton
     root.parent = empty
         #arm.pose.bones[ix].matrix        
     bpy.ops.object.editmode_toggle()
-    for obj in bpy.context.scene.objects:
+    for obj in bpy.context.scene.collection.objects:
         if obj.type == "MESH":
             m = obj.modifiers.new("Armature","ARMATURE")
             m.object = arm_ob
@@ -66,6 +66,6 @@ class ConvertAHI(Operator):
     bl_options = {'REGISTER', 'PRESET', 'UNDO'}
     
     def execute(self,context):
-        roots = [ o for o in bpy.context.scene.objects if o.type == "EMPTY" and o.parent is None ]
+        roots = [ o for o in bpy.context.scene.collection.objects if o.type == "EMPTY" and o.parent is None ]
         for root in roots: createArmature(root)
         return {'FINISHED'}

--- a/operators/ahi_import.py
+++ b/operators/ahi_import.py
@@ -18,8 +18,8 @@ class ImportFUAHI(Operator, ImportHelper):
  
     # ImportHelper mixin class uses this
     filename_ext = ".fskl"
-    filter_glob = StringProperty(default="*.ahi", options={'HIDDEN'}, maxlen=255)
-    import_armature = BoolProperty(name = "Import as Armature", default = False)
+    filter_glob: StringProperty(default="*.ahi", options={'HIDDEN'}, maxlen=255)
+    import_armature: BoolProperty(name = "Import as Armature", default = False)
     
     def execute(self,context):
         try:

--- a/struct/ahi_importer_layer.py
+++ b/struct/ahi_importer_layer.py
@@ -20,7 +20,7 @@ class AHIImporter():
         skeleton = FUSkeleton(fmodPath).skeletonStructure()
         currentSkeleton = {}
         o = bpy.data.objects.new("Armature", None)
-        bpy.context.scene.objects.link(o)
+        bpy.context.scene.collection.objects.link(o)
         # bpy.context.scene.update()
         currentSkeleton = {"Armature": o}
         for bone in skeleton.values():
@@ -41,7 +41,7 @@ class AHIImporter():
             return
         o = bpy.data.objects.new("Bone.%03d" % ix, None)
         skeleton["Bone.%03d" % ix] = o
-        bpy.context.scene.objects.link(o)
+        bpy.context.scene.collection.objects.link(o)
         parentName = "Armature" if bone.parentID == -1 else "Bone.%03d" % bone.parentID
         if parentName not in skeleton:
             AHIImporter.importBone(
@@ -50,5 +50,5 @@ class AHIImporter():
         o.parent = skeleton[parentName]
         o.matrix_local = AHIImporter.deserializePoseVector(bone.posVec)
         o.show_wire = True
-        o.show_x_ray = True
+        o.show_in_front = True
         o.show_bounds = True


### PR DESCRIPTION
This adds support for blender versions 2.80+.

Currently broken:
- [ ] bone position on ConvertAHI
- [ ] no suitable replacement for `meshpart.show_edge_sharp = True` found

Tested on 3.0.1 so far.